### PR TITLE
Make hooks work on Windows

### DIFF
--- a/src/main/java/com/github/tjni/captainhook/helpers/ApplyGitHooksHelper.java
+++ b/src/main/java/com/github/tjni/captainhook/helpers/ApplyGitHooksHelper.java
@@ -136,7 +136,7 @@ public class ApplyGitHooksHelper {
 
   private static String getGitHookCommand(Path gitHooksDir, GitHook gitHook) {
     Path gitHookScriptFile = gitHooksDir.relativize(getGitHookScriptFile(gitHooksDir, gitHook));
-    return "`dirname \"$0\"`" + File.separatorChar + gitHookScriptFile;
+    return "`dirname \"$0\"`" + "/" + gitHookScriptFile;
   }
 
   private Path addGitHook(Path gitHooksDir, GitHook gitHook) {


### PR DESCRIPTION
Replace platform-dependent path separator with `/`, since the script will be executed with bash on Windows as well.